### PR TITLE
Fix pandas 2.0+ frequency alias compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   ref:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
 
     python_requires='>=3.8,<3.12',
     install_requires=[
-        'numpy>1.21', 'pandas>=2.1', 'scipy', 'dill', 'matplotlib',
+        'numpy>1.21', 'pandas>=1.0', 'scipy', 'dill', 'matplotlib',
         'pyomo>=6', 'gurobipy',
         'gridx-egret @ git+https://github.com/shrivats-pu/Egret.git'
         ],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
 
     python_requires='>=3.8,<3.12',
     install_requires=[
-        'numpy>1.21', 'pandas', 'scipy', 'dill', 'matplotlib',
+        'numpy>1.21', 'pandas>=2.1', 'scipy', 'dill', 'matplotlib',
         'pyomo>=6', 'gurobipy',
         'gridx-egret @ git+https://github.com/shrivats-pu/Egret.git'
         ],

--- a/vatic/compat.py
+++ b/vatic/compat.py
@@ -1,0 +1,29 @@
+"""Compatibility utilities for different dependency versions."""
+
+import pandas as pd
+
+
+def hourly_resample(df_or_series):
+    """Resample to hourly frequency with backward compatibility.
+
+    pandas 2.2+ requires lowercase frequency aliases ('h'),
+    while older versions use uppercase ('H').
+    """
+    try:
+        return df_or_series.resample('h')
+    except ValueError:
+        return df_or_series.resample('H')
+
+
+def hourly_freq():
+    """Return the hourly frequency string compatible with installed pandas.
+
+    pandas 2.2+ requires lowercase frequency aliases ('h'),
+    while older versions use uppercase ('H').
+    """
+    try:
+        # Test if lowercase works
+        pd.date_range(start='2020-01-01', periods=1, freq='h')
+        return 'h'
+    except ValueError:
+        return 'H'

--- a/vatic/data/loaders.py
+++ b/vatic/data/loaders.py
@@ -33,6 +33,8 @@ import math
 import pandas as pd
 from datetime import datetime
 
+from vatic.compat import hourly_resample
+
 import os
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -566,8 +568,8 @@ class GridLoader(ABC):
             load_fcsts = self.get_forecasts('Load', start_date, end_date)
 
         if load_actls is None:
-            load_actls = self.get_actuals(
-                'Load', start_date, end_date).resample('H').mean()
+            load_actls = hourly_resample(
+                self.get_actuals('Load', start_date, end_date)).mean()
 
         site_dfs = dict()
         for zone, zone_df in self.bus_df.groupby('Area'):
@@ -628,8 +630,8 @@ class GridLoader(ABC):
 
         for asset_type in self.timeseries_cohorts:
             gen_fcsts = self.get_forecasts(asset_type, start_date, end_date)
-            gen_actls = self.get_actuals(
-                asset_type, start_date, end_date).resample('H').mean()
+            gen_actls = hourly_resample(
+                self.get_actuals(asset_type, start_date, end_date)).mean()
 
             gen_fcsts.columns = pd.MultiIndex.from_tuples(
                 [('fcst', asset_name) for asset_name in gen_fcsts.columns])
@@ -714,8 +716,8 @@ class GridLoader(ABC):
         gen_df = pd.concat([gen_df, gen_scens], axis=1)
 
         for asset_type in self.no_scenario_renews:
-            new_actuals = self.get_actuals(
-                asset_type, start_date, end_date).resample('H').mean()
+            new_actuals = hourly_resample(
+                self.get_actuals(asset_type, start_date, end_date)).mean()
 
             for asset_name, asset_actuals in new_actuals.iteritems():
                 gen_df['actl', asset_name] = asset_actuals

--- a/vatic/data_providers.py
+++ b/vatic/data_providers.py
@@ -665,7 +665,7 @@ class PickleProvider:
             # we can just copy the final value of the first day
             else:
                 day_data['MaxNondispatchablePower'].update({
-                    (gen, i): float(gen_data[gen][-1]) for i in range(25, 49)})
+                    (gen, i): float(gen_data[gen].iloc[-1]) for i in range(25, 49)})
 
         # for dispatchable renewables, minimum output is always zero
         for gen in self.template['DispatchRenewables']:

--- a/vatic/stats_manager.py
+++ b/vatic/stats_manager.py
@@ -387,17 +387,17 @@ class StatsManager:
             tgen_gby = report_dfs['thermal_detail'].groupby('Generator')
 
             # get the final output for each generator
-            final_dispatch = tgen_gby.apply(lambda x: round(x['Dispatch'][-1], 2))
+            final_dispatch = tgen_gby.apply(lambda x: round(x['Dispatch'].iloc[-1], 2))
 
             # get the final on/off state for each generator
             final_bool = tgen_gby.apply(
-                lambda x: (x['Unit State'][-1] * 2 - 1))
+                lambda x: (x['Unit State'].iloc[-1] * 2 - 1))
 
             # find how long it has been since each generator was in a state not
             # matching its final state, combine this info with final on/off
             last_conds = tgen_gby.apply(
                 lambda x: (x['Unit State']
-                           != x['Unit State'][-1])[::-1].argmax()
+                           != x['Unit State'].iloc[-1])[::-1].argmax()
                 ) * final_bool
 
             # for generators which were on or off for the entire simulation

--- a/vatic/stats_manager.py
+++ b/vatic/stats_manager.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 from .model_data import VaticModelData
 from .time_manager import VaticTime
+from .compat import hourly_freq
 
 import matplotlib.pyplot as plt
 import seaborn as sns
@@ -603,7 +604,7 @@ class StatsManager:
                 t.strftime('%m/%d\n%-I%p') if i % 6 == 0 else ""
                 for i, t in enumerate(pd.date_range(start=ruc_time.when,
                                                     periods=commits.shape[1],
-                                                    freq='H'))
+                                                    freq=hourly_freq()))
                 ]
 
             ylbls = [


### PR DESCRIPTION
Fixes #6

## Summary

Fixes pandas 2.x compatibility while maintaining support for older versions.

### Frequency alias compatibility (`'H'` vs `'h'`)
pandas 2.2+ requires lowercase frequency aliases (`'h'`), while older versions use uppercase (`'H'`).

**Strategy:** Created `vatic/compat.py` with helper functions that use try/except to handle both:
- `hourly_resample(series)` — tries `resample('h')`, falls back to `resample('H')`
- `hourly_freq()` — returns `'h'` or `'H'` depending on what the installed pandas accepts

### Positional indexing (`[-1]` → `.iloc[-1]`)
Newer pandas interprets `series[-1]` as a label lookup on DatetimeIndex, causing `KeyError: -1`.

**Strategy:** Replaced with `.iloc[-1]` which is the correct positional accessor and has been available since pandas 0.11 (2013) — no compatibility shim needed.

### Other changes
- Set `pandas>=1.0` in setup.py (pandas 2.1+ requires Python 3.9+, so we can't pin higher while supporting Python 3.8)
- Update ref job to ubuntu-22.04 for better runner availability

## Test plan
- [ ] CI passes on ubuntu-latest with Python 3.8, 3.9, 3.10, 3.11
- [ ] ref job completes successfully on ubuntu-22.04